### PR TITLE
fix: add clients response value to servergroupclientlist

### DIFF
--- a/servergroup.go
+++ b/servergroup.go
@@ -235,7 +235,7 @@ func (c *TeamspeakHttpClient) ServerGroupClientList(serverGroupId int) (*[]Serve
 			ServerGroupId: serverGroupId,
 			Names:         true,
 		},
-		nil,
+		&clients,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
At the moment, when retrieving the server group client list, the result is not being parsed - this pull request fixes this unwanted behaviour by passing the client slice pointer to the request method.