### PR TITLE
Create TLSConfig if missing

### DIFF
--- a/tshttpclient.go
+++ b/tshttpclient.go
@@ -1,6 +1,7 @@
 package go_ts3
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"github.com/asaskevich/EventBus"
@@ -38,6 +39,9 @@ func (c *TeamspeakHttpClient) SetServerID(serverID int) {
 }
 
 func (c *TeamspeakHttpClient) SetInsecure(allowInsecure bool) {
+	if c.httpClient.TLSConfig == nil {
+		c.httpClient.TLSConfig = &tls.Config{}
+	}
 	c.httpClient.TLSConfig.InsecureSkipVerify = allowInsecure
 }
 

--- a/tshttpclient.go
+++ b/tshttpclient.go
@@ -42,6 +42,7 @@ func (c *TeamspeakHttpClient) SetInsecure(allowInsecure bool) {
 	if c.httpClient.TLSConfig == nil {
 		c.httpClient.TLSConfig = &tls.Config{}
 	}
+
 	c.httpClient.TLSConfig.InsecureSkipVerify = allowInsecure
 }
 


### PR DESCRIPTION
My last PR #3 introduced a bug. If the `TLSConfig` is missing in the used `fasthttp.Client`, it will be created now.
